### PR TITLE
Add websocket swarm address

### DIFF
--- a/roles/ipfs/templates/home/ipfs/ipfs_default_config
+++ b/roles/ipfs/templates/home/ipfs/ipfs_default_config
@@ -22,7 +22,9 @@
   "Addresses": {
     "Swarm": [
       "/ip4/0.0.0.0/tcp/4001",
-      "/ip6/::/tcp/4001"
+      "/ip4/0.0.0.0/tcp/4001/ws",
+      "/ip6/::/tcp/4001",
+      "/ip6/::/tcp/4001/ws"
     ],
     "Announce": [],
     "NoAnnounce": [],


### PR DESCRIPTION
Making the cluster peers available over websockets so js-ipfs clients can connect directly to them.