### PR TITLE
chore: update cluster to 0.10

### DIFF
--- a/group_vars/ipfs.yml
+++ b/group_vars/ipfs.yml
@@ -1,5 +1,5 @@
 dist_url: https://dist.ipfs.io
-ipfs_version: v0.4.13
+ipfs_version: v0.4.19
 ipfs_arch: amd64
 ipfs_home: /home/ipfs
 ipfs_storage_max: 10G
@@ -8,7 +8,7 @@ ipfs_api_listen: /ip4/127.0.0.1/tcp/5001
 
 ipfs_cluster_secret: "use `od  -vN 32 -An -tx1 /dev/urandom | tr -d ' \n' ; echo` to generate this"
 ipfs_cluster_arch: amd64
-ipfs_cluster_version: v0.3.4
+ipfs_cluster_version: v0.10.0
 
 
 ipfs_cluster_state_sync_interval: 1m


### PR DESCRIPTION
Updates default config to fetch

- cluster `0.10.0`
- ipfs `0.4.19`

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>